### PR TITLE
Bug fix for Forts

### DIFF
--- a/FortMod/Server_AdvanceTurn.lua
+++ b/FortMod/Server_AdvanceTurn.lua
@@ -45,12 +45,13 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder, addNewOrde
 
 		local terrMod = WL.TerritoryModification.Create(order.To);
 		terrMod.SetStructuresOpt = structures;
-		addNewOrder(WL.GameOrderEvent.Create(order.PlayerID, 'Destroyed a fort', {}, {terrMod}));
+		addNewOrder(WL.GameOrderEvent.Create(order.PlayerID, 'Destroyed a fort', {}, {terrMod}), true);		-- The second argument makes sure this order isn't processed when the initial attack is skipped
 
 
 		if (result.DefendingArmiesKilled.IsEmpty) then
-			--A successful attack on a territory where no defending armies were killed must mean it was a territory defended by 0 armies.  In this case, we can't stop the attack by simply setting DefendingArmiesKilled to 0, since attacks against 0 are always successful.  So instead, we simply skip the entire attack.
-			skipThisOrder(WL.ModOrderControl.Skip);
+			-- A successful attack on a territory where no defending armies were killed must mean it was a territory defended by 0 armies.  In this case, we can't stop the attack by simply setting DefendingArmiesKilled to 0, since attacks against 0 are always successful. 
+			-- Instead of skipping the order, we can set the ActualArmies to 0, to make it a 0 army attack. Skipping the order would also skip the destroy fort order
+			result.ActualArmies = WL.Armies.Create(0);
 		else
 			result.DefendingArmiesKilled = WL.Armies.Create(0);
 		end


### PR DESCRIPTION
The forts mod would destroy a fort, even when the initial attack would be skipped by another mod.